### PR TITLE
[ci-run][fix][flaky-test]NegativeAcksTest.testNegativeAcksWithBatchAckEnabled

### DIFF
--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -297,7 +297,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         negativeAcksTracker.close();
     }
 
-    @Test(timeOut = 15000)
+    @Test(timeOut = 10000)
     public void testNegativeAcksWithBatchAckEnabled() throws Exception {
         cleanup();
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -311,8 +311,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
                 .subscriptionType(SubscriptionType.Shared)
                 .enableBatchIndexAcknowledgment(true)
-                .negativeAckRedeliveryDelay(2, TimeUnit.SECONDS)
-                .ackTimeout(1, TimeUnit.SECONDS)
+                .negativeAckRedeliveryDelay(1, TimeUnit.SECONDS)
                 .subscribe();
 
         @Cleanup

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/NegativeAcksTest.java
@@ -297,7 +297,7 @@ public class NegativeAcksTest extends ProducerConsumerBase {
         negativeAcksTracker.close();
     }
 
-    @Test(timeOut = 10000)
+    @Test(timeOut = 15000)
     public void testNegativeAcksWithBatchAckEnabled() throws Exception {
         cleanup();
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
@@ -311,7 +311,8 @@ public class NegativeAcksTest extends ProducerConsumerBase {
                 .acknowledgmentGroupTime(0, TimeUnit.SECONDS)
                 .subscriptionType(SubscriptionType.Shared)
                 .enableBatchIndexAcknowledgment(true)
-                .ackTimeout(1000, TimeUnit.MILLISECONDS)
+                .negativeAckRedeliveryDelay(2, TimeUnit.SECONDS)
+                .ackTimeout(1, TimeUnit.SECONDS)
                 .subscribe();
 
         @Cleanup


### PR DESCRIPTION
relate to:

- https://github.com/apache/pulsar/pull/17893

`/pulsarbot rerun-failure-checks`