### PR TITLE
[ci] [improve] [broker] Makes getLastMessageId more efficient if read compacted

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ServerCnx.java
@@ -1998,7 +1998,10 @@ public class ServerCnx extends PulsarHandler implements TransportCnx {
                 MessageMetadata metadata = Commands.parseMessageMetadata(payload);
                 int largestBatchIndex;
                 try {
-                    largestBatchIndex = calculateTheLastBatchIndexInBatch(metadata, payload);
+                    Optional<Integer> lastMsgBatchIndex =
+                            persistentTopic.getCompactedTopic().getLastMessageIdBatchIndex();
+                    largestBatchIndex = lastMsgBatchIndex.isPresent() ? lastMsgBatchIndex.get()
+                            : calculateTheLastBatchIndexInBatch(metadata, payload);
                 } catch (IOException ioEx){
                     ctx.writeAndFlush(Commands.newError(requestId, ServerError.MetadataError,
                             "Failed to deserialize batched message from the last entry of the compacted Ledger: "

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopic.java
@@ -27,7 +27,8 @@ import org.apache.bookkeeper.mledger.Position;
 import org.apache.pulsar.broker.service.Consumer;
 
 public interface CompactedTopic {
-    CompletableFuture<CompactedTopicContext> newCompactedLedger(Position p, long compactedLedgerId);
+    CompletableFuture<CompactedTopicContext> newCompactedLedger(Position p, long compactedLedgerId,
+                                                                Integer lastMsgIdBatchIndex);
     CompletableFuture<Void> deleteCompactedLedger(long compactedLedgerId);
     void asyncReadEntriesOrWait(ManagedCursor cursor,
                                 int numberOfEntriesToRead,
@@ -36,4 +37,6 @@ public interface CompactedTopic {
                                 Consumer consumer);
     CompletableFuture<Entry> readLastEntryOfCompactedLedger();
     Optional<Position> getCompactionHorizon();
+
+    Optional<Integer> getLastMessageIdBatchIndex();
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/CompactedTopicImpl.java
@@ -60,6 +60,7 @@ public class CompactedTopicImpl implements CompactedTopic {
     private final BookKeeper bk;
 
     private PositionImpl compactionHorizon = null;
+    private Integer lastMessageIdBatchIndex;
     private CompletableFuture<CompactedTopicContext> compactedTopicContext = null;
 
     public CompactedTopicImpl(BookKeeper bk) {
@@ -67,10 +68,11 @@ public class CompactedTopicImpl implements CompactedTopic {
     }
 
     @Override
-    public CompletableFuture<CompactedTopicContext> newCompactedLedger(Position p, long compactedLedgerId) {
+    public CompletableFuture<CompactedTopicContext> newCompactedLedger(Position p, long compactedLedgerId,
+                                                                       Integer lastMessageIdBatchIndex) {
         synchronized (this) {
             compactionHorizon = (PositionImpl) p;
-
+            lastMessageIdBatchIndex = lastMessageIdBatchIndex;
             CompletableFuture<CompactedTopicContext> previousContext = compactedTopicContext;
             compactedTopicContext = openCompactedLedger(bk, compactedLedgerId);
 
@@ -320,6 +322,11 @@ public class CompactedTopicImpl implements CompactedTopic {
     public synchronized Optional<Position> getCompactionHorizon() {
         return Optional.ofNullable(this.compactionHorizon);
     }
+
+    public synchronized Optional<Integer> getLastMessageIdBatchIndex() {
+        return Optional.ofNullable(this.lastMessageIdBatchIndex);
+    }
+
     private static final Logger log = LoggerFactory.getLogger(CompactedTopicImpl.class);
 }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/Compactor.java
@@ -35,6 +35,8 @@ public abstract class Compactor {
     private static final Logger log = LoggerFactory.getLogger(Compactor.class);
     public static final String COMPACTION_SUBSCRIPTION = "__compaction";
     public static final String COMPACTED_TOPIC_LEDGER_PROPERTY = "CompactedTopicLedger";
+    public static final String COMPACTED_TOPIC_LAST_MESSAGE_ID_BATCH_INDEX_PROPERTY =
+            "CompactedTopicLastMessageIdBatchIndex";
     static final BookKeeper.DigestType COMPACTED_TOPIC_LEDGER_DIGEST_TYPE = BookKeeper.DigestType.CRC32;
     static final byte[] COMPACTED_TOPIC_LEDGER_PASSWORD = "".getBytes(UTF_8);
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/compaction/TwoPhaseCompactor.java
@@ -76,6 +76,7 @@ public class TwoPhaseCompactor extends Compactor {
                 .thenCompose(available -> {
                     if (available) {
                         return phaseOne(reader).thenCompose(
+                                // TODO calculate the last messageId in the kv map.
                                 (r) -> phaseTwo(reader, r.from, r.to, r.lastReadId, r.latestForKey, bk));
                     } else {
                         log.info("Skip compaction of the empty topic {}", reader.getTopic());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -25,6 +25,7 @@ import static org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest.createMo
 import static org.apache.pulsar.common.protocol.Commands.DEFAULT_CONSUMER_EPOCH;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.atLeast;
@@ -1874,7 +1875,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
     public void testCompactorSubscription() throws Exception {
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         CompactedTopic compactedTopic = mock(CompactedTopic.class);
-        when(compactedTopic.newCompactedLedger(any(Position.class), anyLong()))
+        when(compactedTopic.newCompactedLedger(any(Position.class), anyLong(), anyInt()))
                 .thenReturn(CompletableFuture.completedFuture(mock(CompactedTopicContext.class)));
         PersistentSubscription sub = new CompactorSubscription(topic, compactedTopic,
                                                                Compactor.COMPACTION_SUBSCRIPTION,
@@ -1883,7 +1884,7 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         long ledgerId = 0xc0bfefeL;
         sub.acknowledgeMessage(Collections.singletonList(position), AckType.Cumulative,
                 Map.of(Compactor.COMPACTED_TOPIC_LEDGER_PROPERTY, ledgerId));
-        verify(compactedTopic, Mockito.times(1)).newCompactedLedger(position, ledgerId);
+        verify(compactedTopic, Mockito.times(1)).newCompactedLedger(position, ledgerId, null);
     }
 
 
@@ -1898,10 +1899,10 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
 
         PersistentTopic topic = new PersistentTopic(successTopicName, ledgerMock, brokerService);
         CompactedTopic compactedTopic = mock(CompactedTopic.class);
-        when(compactedTopic.newCompactedLedger(any(Position.class), anyLong()))
+        when(compactedTopic.newCompactedLedger(any(Position.class), anyLong(), anyInt()))
                 .thenReturn(CompletableFuture.completedFuture(null));
         new CompactorSubscription(topic, compactedTopic, Compactor.COMPACTION_SUBSCRIPTION, cursorMock);
-        verify(compactedTopic, Mockito.times(1)).newCompactedLedger(position, ledgerId);
+        verify(compactedTopic, Mockito.times(1)).newCompactedLedger(position, ledgerId, null);
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/compaction/CompactedTopicTest.java
@@ -233,7 +233,7 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
 
         // set the compacted topic ledger
         CompactedTopicImpl compactedTopic = new CompactedTopicImpl(bk);
-        compactedTopic.newCompactedLedger(new PositionImpl(1,2), oldCompactedLedger.getId()).get();
+        compactedTopic.newCompactedLedger(new PositionImpl(1,2), oldCompactedLedger.getId(), null).get();
 
         // ensure both ledgers still exist, can be opened
         bk.openLedger(oldCompactedLedger.getId(),
@@ -245,7 +245,7 @@ public class CompactedTopicTest extends MockedPulsarServiceBaseTest {
 
         // update the compacted topic ledger
         PositionImpl newHorizon = new PositionImpl(1,3);
-        compactedTopic.newCompactedLedger(newHorizon, newCompactedLedger.getId()).get();
+        compactedTopic.newCompactedLedger(newHorizon, newCompactedLedger.getId(), null).get();
 
         // Make sure the old compacted ledger still exist after the new compacted ledger created.
         bk.openLedger(oldCompactedLedger.getId(),


### PR DESCRIPTION
### Motivation
Pulsar's topic compaction feature enables to create compacted topics in which older, "obscured" entries are pruned from the topic, allowing for faster reads through the topic's history.

After consumer enabled read compacted, if we call `consumer.getLastMessageId` will return the last non-empty message in the compacted topic, and If the messages is batched-messages will extract the batched-message and return the last non-empty internal message.

<strong>(High light)</strong>
Extract the batched message is not a lightweight logic, if there are many consumer read enabled compacted, method `consumer.getLastMessageId` is called frequently, this consumes a lot of broker resources.

### Modifications
When a compaction task executes, we record the batch index of the last non-empty message to the ack properties, just like we record the ledger id of compacted topic. So we can save the resources of extract batched messages when calling `consumer.getLastMessages`.

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository:
- nothing
