### PR TITLE
[ci] [fix] [admin] set offload threshold should fail when ns policies is readonly

### DIFF
--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/resources/NamespaceResources.java
@@ -50,7 +50,7 @@ public class NamespaceResources extends BaseResources<Policies> {
     private final PartitionedTopicResources partitionedTopicResources;
     private final MetadataStore configurationStore;
 
-    private static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
+    public static final String POLICIES_READONLY_FLAG_PATH = "/admin/flags/policies-readonly";
     private static final String NAMESPACE_BASE_PATH = "/namespace";
     private static final String BUNDLE_DATA_BASE_PATH = "/loadbalance/bundle-data";
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/NamespacesBase.java
@@ -2046,7 +2046,7 @@ public abstract class NamespacesBase extends AdminResource {
         CompletableFuture<Void> f = new CompletableFuture<>();
 
         validateNamespacePolicyOperationAsync(namespaceName, PolicyName.OFFLOAD, PolicyOperation.WRITE)
-                .thenApply(v -> validatePoliciesReadOnlyAccessAsync())
+                .thenCompose(v -> validatePoliciesReadOnlyAccessAsync())
                 .thenCompose(v -> updatePoliciesAsync(namespaceName,
                         policies -> {
                             if (policies.offload_policies == null) {

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -293,7 +293,6 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
         assertEquals(admin.namespaces().getOffloadPolicies(myNamespace), policies);
     }
 
-
     @Test
     public void testSetNamespaceOffloadPoliciesFailByReadOnly() throws Exception {
         pulsar.getConfigurationMetadataStore().put(NamespaceResources.POLICIES_READONLY_FLAG_PATH, "0".getBytes(),

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -295,17 +295,22 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
 
     @Test
     public void testSetNamespaceOffloadPoliciesFailByReadOnly() throws Exception {
-        pulsar.getConfigurationMetadataStore().put(NamespaceResources.POLICIES_READONLY_FLAG_PATH, "0".getBytes(),
-                Optional.empty()).join();
+        boolean setNsPolicyReadOnlySuccess = false;
         try {
+            pulsar.getConfigurationMetadataStore().put(NamespaceResources.POLICIES_READONLY_FLAG_PATH, "0".getBytes(),
+                    Optional.empty()).join();
+            setNsPolicyReadOnlySuccess = true;
             admin.namespaces().setOffloadThresholdInSeconds(myNamespace, 300);
             fail("set offload threshold should fail when ns policies is readonly");
         } catch (Exception ex){
             // ignore.
+        } finally {
+            // cleanup.
+            if (setNsPolicyReadOnlySuccess) {
+                pulsar.getConfigurationMetadataStore().delete(NamespaceResources.POLICIES_READONLY_FLAG_PATH,
+                        Optional.empty()).join();
+            }
         }
-        // cleanup.
-        pulsar.getConfigurationMetadataStore().delete(NamespaceResources.POLICIES_READONLY_FLAG_PATH,
-                Optional.empty()).join();
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApiOffloadTest.java
@@ -47,14 +47,17 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedLedgerInfo;
 import org.apache.pulsar.broker.auth.MockedPulsarServiceBaseTest;
+import org.apache.pulsar.broker.resources.NamespaceResources;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
 import org.apache.pulsar.client.admin.PulsarAdminException.ConflictException;
@@ -288,6 +291,22 @@ public class AdminApiOffloadTest extends MockedPulsarServiceBaseTest {
 
         admin.namespaces().setOffloadPolicies(myNamespace, policies);
         assertEquals(admin.namespaces().getOffloadPolicies(myNamespace), policies);
+    }
+
+
+    @Test
+    public void testSetNamespaceOffloadPoliciesFailByReadOnly() throws Exception {
+        pulsar.getConfigurationMetadataStore().put(NamespaceResources.POLICIES_READONLY_FLAG_PATH, "0".getBytes(),
+                Optional.empty()).join();
+        try {
+            admin.namespaces().setOffloadThresholdInSeconds(myNamespace, 300);
+            fail("set offload threshold should fail when ns policies is readonly");
+        } catch (Exception ex){
+            // ignore.
+        }
+        // cleanup.
+        pulsar.getConfigurationMetadataStore().delete(NamespaceResources.POLICIES_READONLY_FLAG_PATH,
+                Optional.empty()).join();
     }
 
     @Test


### PR DESCRIPTION
`/pulsarbot rerun-failure-checks`