### PR TITLE
[ci] [fix] [broker] Make the service name resolver cache of PulsarWebResource expire after access

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/web/PulsarWebResource.java
@@ -103,7 +103,7 @@ public abstract class PulsarWebResource {
     private static final Logger log = LoggerFactory.getLogger(PulsarWebResource.class);
 
     private static final LoadingCache<String, PulsarServiceNameResolver> SERVICE_NAME_RESOLVER_CACHE =
-            Caffeine.newBuilder().expireAfterWrite(Duration.ofMinutes(5)).build(
+            Caffeine.newBuilder().expireAfterAccess(Duration.ofMinutes(5)).build(
                     new CacheLoader<>() {
                         @Override
                         public @Nullable PulsarServiceNameResolver load(@NonNull String serviceUrl) throws Exception {


### PR DESCRIPTION
`/pulsarbot rerun-failure-checks`