### PR TITLE
[fix] [broker] Ignore and remove the replicator cursor when the remot…

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1747,6 +1747,7 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                             });
                         } else {
                             // Start replication is failed.
+                            log.error("[{}] The replicator startup failed {}", topic, remoteCluster, ex);
                             replicationStartFuture.completeExceptionally(ex);
                             return CompletableFuture.completedFuture(null);
                         }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1734,17 +1734,19 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                         if (!clusterExists) {
                             log.warn("[{}] Start remove the replicator because the cluster '{}' does not exist",
                                     topic, remoteCluster);
-                            replicationStartFuture.complete(null);
-                            return removeReplicator(remoteCluster).whenComplete((ignore2, remoteCursorEx) -> {
-                                if (remoteCursorEx != null) {
+                            return removeReplicator(remoteCluster).whenComplete((ignore2, removeCursorEx) -> {
+                                if (removeCursorEx != null) {
                                     log.error("[{}] Remove the cursor of replicator[{}] is failed, please reload topic."
                                             , topic, remoteCluster);
+                                    replicationStartFuture.failedFuture(removeCursorEx);
                                 } else {
                                     log.warn("[{}] Remove the cursor of replicator[{}] successfully",
                                             topic, remoteCluster);
+                                    replicationStartFuture.complete(null);
                                 }
                             });
                         } else {
+                            log.info("===> {}", ex.getMessage());
                             // Start replication is failed.
                             replicationStartFuture.completeExceptionally(ex);
                             return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentTopic.java
@@ -1746,7 +1746,6 @@ public class PersistentTopic extends AbstractTopic implements Topic, AddEntryCal
                                 }
                             });
                         } else {
-                            log.info("===> {}", ex.getMessage());
                             // Start replication is failed.
                             replicationStartFuture.completeExceptionally(ex);
                             return CompletableFuture.completedFuture(null);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -561,11 +561,11 @@ public class PersistentTopicTest extends BrokerTestBase {
         if (topicLevelPolicy) {
             // setReplicationClusters may fail, so do retry.
             Awaitility.await().ignoreExceptions().untilAsserted(() -> {
-                admin.topics().setReplicationClusters(topicName, Arrays.asList(remoteCluster, "test"));
+                admin.topics().setReplicationClusters(topicName, Collections.singletonList(remoteCluster));
             });
         } else {
             admin.namespaces().setNamespaceReplicationClustersAsync(
-                    namespace, new HashSet<>(Arrays.asList(remoteCluster, "test"))).get();
+                    namespace, Collections.singleton(remoteCluster)).get();
         }
 
         final PersistentTopic topic = (PersistentTopic) pulsar.getBrokerService().getTopic(topicName, false)

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -581,16 +581,16 @@ public class PersistentTopicTest extends BrokerTestBase {
         assertEquals(getCursors.get(), Collections.singleton(conf.getReplicatorPrefix() + "." + remoteCluster));
 
         if (topicLevelPolicy) {
-            admin.topics().setReplicationClusters(topicName, Collections.singletonList("test"));
+            admin.topics().setReplicationClusters(topicName, Collections.emptyList());
         } else {
-            admin.namespaces().setNamespaceReplicationClustersAsync(namespace, Collections.singleton("test")).get();
+            admin.namespaces().setNamespaceReplicationClustersAsync(namespace, Collections.emptySet()).get();
         }
         admin.clusters().deleteCluster(remoteCluster);
         // Now the cluster and its related policy has been removed but the replicator cursor still exists
 
         // Verify:
-        // 1. Topic can load success( use "topic.initialize()" instead of "load topic" ).
-        //    If the topic loading by client is failed, it will retry, so we can do retry "topic.initialize()".
+        // 1. Topic can load success. If the topic loading by client is failed, it will retry,
+        //    so we can do retry "initialize topic".
         // 2. The repl cursor will be deleted.
         Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
             topic.initialize().get(3, TimeUnit.SECONDS);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -593,8 +593,8 @@ public class PersistentTopicTest extends BrokerTestBase {
         //    If the topic loading by client is failed, it will retry, so we can do retry "topic.initialize()".
         // 2. The repl cursor will be deleted.
         Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
-                    topic.initialize().get(3, TimeUnit.SECONDS);
-                    assertFalse(topic.getManagedLedger().getCursors().iterator().hasNext());
-                });
+            topic.initialize().get(3, TimeUnit.SECONDS);
+            assertFalse(topic.getManagedLedger().getCursors().iterator().hasNext());
+        });
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -560,13 +560,8 @@ public class PersistentTopicTest extends BrokerTestBase {
 
         if (topicLevelPolicy) {
             // setReplicationClusters may fail, so do retry.
-            Awaitility.await().until(() -> {
-                try {
-                    admin.topics().setReplicationClusters(topicName, Arrays.asList(remoteCluster, "test"));
-                    return true;
-                } catch (Exception ex) {
-                    return false;
-                }
+            Awaitility.await().ignoreExceptions().untilAsserted(() -> {
+                admin.topics().setReplicationClusters(topicName, Arrays.asList(remoteCluster, "test"));
             });
         } else {
             admin.namespaces().setNamespaceReplicationClustersAsync(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/persistent/PersistentTopicTest.java
@@ -592,10 +592,9 @@ public class PersistentTopicTest extends BrokerTestBase {
         // 1. Topic can load success( use "topic.initialize()" instead of "load topic" ).
         //    If the topic loading by client is failed, it will retry, so we can do retry "topic.initialize()".
         // 2. The repl cursor will be deleted.
-        Awaitility.await().atMost(10, TimeUnit.SECONDS)
-                .until(() -> {
+        Awaitility.await().atMost(10, TimeUnit.SECONDS).ignoreExceptions().untilAsserted(() -> {
                     topic.initialize().get(3, TimeUnit.SECONDS);
-                    return !topic.getManagedLedger().getCursors().iterator().hasNext();
+                    assertFalse(topic.getManagedLedger().getCursors().iterator().hasNext());
                 });
     }
 }


### PR DESCRIPTION
`/pulsarbot rerun-failure-checks`